### PR TITLE
Add test for device ID authentication and fix session creation

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,23 @@
+package nakama
+
+import (
+	"testing"
+)
+
+func TestAuthenticateWithDeviceId(t *testing.T) {
+	deviceId := "376C007D-260F-579B-BD75-A3CBBFC2EF99"
+
+	client := NewClient("defaultkey", "127.0.0.1", "7350", false, nil, nil)
+
+	create := true
+
+	session, err := client.AuthenticateDevice(deviceId, &create, nil, nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if session == nil {
+		t.Error("Session is nil")
+	}
+}

--- a/client.go
+++ b/client.go
@@ -422,11 +422,18 @@ func (c *Client) AuthenticateDevice(id string, create *bool, username *string, v
 		return nil, err
 	}
 
+	created := false
+	if apiSession.Created != nil {
+		created = *apiSession.Created
+	} else if create != nil {
+		created = *create
+	}
+
 	// Return a new Session object
 	return &Session{
 		Token:        *apiSession.Token,
 		RefreshToken: *apiSession.RefreshToken,
-		Created:      *apiSession.Created,
+		Created:      created,
 	}, nil
 }
 


### PR DESCRIPTION
Introduce a unit test to validate device ID authentication functionality. Adjust session creation logic to handle cases where `apiSession.Created` is nil, falling back to the user-provided `create` parameter if available.