### PR TITLE
Refactor socket handling and remove debug print statements.

### DIFF
--- a/web-socket-adapter.go
+++ b/web-socket-adapter.go
@@ -66,14 +66,13 @@ func (w *WebSocketAdapter) Connect(scheme, host, port string, createStatus bool,
 		return err
 	}
 
-	go w.listen()
+	//go w.listen()
 
 	return nil
 }
 
 // Send sends a message through the WebSocket connection.
 func (w *WebSocketAdapter) Send(message interface{}) error {
-	fmt.Printf("%v", message)
 	w.mu.Lock()
 	defer w.mu.Unlock()
 


### PR DESCRIPTION
Removed unnecessary `fmt.Println` calls and improved error handling in socket operations. Adjusted deserialization logic for `Match` responses and commented out redundant WebSocket listener.